### PR TITLE
Count Atoms Functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.16",
+  "version": "3.0.17",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -27,6 +27,9 @@ export class OperandV3 {
 
   async getObject(req: GetObjectRequest): Promise<Object> {
     let endpoint = `${this.endpoint}/v3/objects/${req.id}`;
+    if (req.includeAtomCount && req.includeAtomCount === true) {
+      endpoint += '?count=true';
+    }
     const response = await fetch(endpoint, {
       method: 'GET',
       headers: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export interface Object {
   indexingStatus: IndexingStatus;
   // Label of the object, optional.
   label?: string;
+  // Atom count of the object and its children, optional.
+  atoms?: number;
 }
 
 // Type of the object determine the type of the metadata
@@ -83,6 +85,7 @@ export type IndexingStatus = 'indexing' | 'ready';
 // Object Endpoints Types
 export type GetObjectRequest = {
   id: string;
+  includeAtomCount?: boolean;
 };
 
 export type ListObjectsRequest = {


### PR DESCRIPTION
Adds an optional parameter to the `getObject()` function which indicates to the server that the number of atoms (within this object or children) should be returned along with the response.

This is mostly for serverless billing purposes.
